### PR TITLE
Error in Ellie ES requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 
             <h3>Extra Stuff (check if valid)</h3>
             
-            Number of Ellies (Requires lv100 Fire):
+            Number of Ellies (Requires lv95 Fire Element):
             <br/>
             <input type="number" id="nEllie" min=0 max=4 value=0>
             <br/> Guild EXP bonus:


### PR DESCRIPTION
Level requirement to use Omni EX skills is 95, not 100.